### PR TITLE
onyx: Opt-in for the cortex-a15's memcpy

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -36,6 +36,7 @@ TARGET_ARCH := arm
 TARGET_ARCH_VARIANT := armv7-a-neon
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
+TARGET_CPU_MEMCPY_BASE_OPT_DISABLE := true
 TARGET_CPU_VARIANT := krait
 
 # Kernel


### PR DESCRIPTION
Yes, while there is a krait specific version of memcpy, it was plagued with issues in regards to krait 2.x/3.x and now some of its faults have been seeded to krait 4.x. It is unlikely this will ever get addressed in the future so let's fix this once and for all by relying on the generic cortex-a15's memcpy as it is the most similar generic ARM platform